### PR TITLE
Change Element mounting `awaits` to improve stability

### DIFF
--- a/Assets/UnityReact/Runtime/UnityReact/Component.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/Component.cs
@@ -110,15 +110,6 @@ namespace Yohash.React
         // the mounting method is awaited so that we can perform
         // async file or web IO to download assets
         element.Component = await element.Mount();
-
-        // ================================================
-        // consider this approach B (compare with below)
-        // ================================================
-        // consider whether we throw an error here or not.
-        // this element is not a React component. Is this an issue?
-        if (element.Component == null) {
-          throw new System.Exception("Mounted non-React component. Breakable?");
-        }
         // once the new child is mounted, run their update method
         updateChildWithProps(element);
         // ================================================
@@ -134,30 +125,12 @@ namespace Yohash.React
 
       // (3) existing elements - to update
       foreach (var child in children) {
-        // ================================================
-        // test out this approach B
-        //  - Test by mounting a component that is NOT
-        //    a Yohash.React.Compnent : IComponent
-        // ================================================
-        // if the component is null, it likely hasn't finished mounting yet
-        // simply continue on, as each component will have its update method
-        // called when it's done mounting
-        if (child.Component == null) { continue; }
-        // update the child component, so it can receive the props update
-        updateChildWithProps(child);
-        // ================================================
-
-        // ================================================
-        // This is the original approach A
-        // if we like approach B, delete this section
-        // ================================================
         // TODO - if the component is null, we need to wait for it to be mounted
         //        Is there any way we can more accurately await the mounter? Rather
         //        than just waiting for a frame? This could result in locked logic too,
         //        if the mounter fails.
         while (child.Component == null) { await Task.Yield(); }
         updateChildWithProps(child);
-        // ================================================
       }
 
       void updateChildWithProps(Element child)


### PR DESCRIPTION
This experiment change our approach to mounting and updating elements… FROM

- await the mounting, and while updating if the component is `null` (mount is still async running) we will `await Task.Yield()` until it's non-null, then call `update` TO
- await the mounting, call `update` after. If the component is `null` while updating, we simply continue

So we will rely on the `update` call to hit AFTER the mount finishes, instead of releasing control via `Yield()`.