### PR TITLE
Properly initialize `Element`

### DIFF
--- a/Assets/UnityReact/CHANGELOG.md
+++ b/Assets/UnityReact/CHANGELOG.md
@@ -5,11 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2024-10-29
+
+### Added
+
+- Modify `IComponent` with an `InitializeElement(PropsContainer, State)` to explicitly initialize mounted `Element`s
+- Added property `bool Props.HasCustomProps`, which is defined by code generation in `PropsGenerator`. We reference this bool in `Component.onStoreInitialize()` and bypass store initialization, waiting for `IComponent.InitializeElement()` instead. This guarantees one "initialization" call in a `Component`, whether it has custom props (an `Element`) or not.
+- Created an asynchronous handle to `Store.Instance` to handle uncontrolled start-up order. If a `Component` subscribes before the `Store` has been created, this new handle allows for a `var store = await Store.Instance` syntax to handle the `null` store instance. 
+
+### Fixed
+
+- Fix a bug where `Element` would initialize (when it ran its `Start()` method) but would have `default` props when `Component.InitializeComponent()` ran until the `Element.UpdateElementWithProps()` ran.
+- Minor fix to handle less-than-0 array indexing in the sample scene
+
+### Changed
+
+- Changed `IComponent.UpdateElementWithProps()` to `IComponent.UpdateElement()`
+- `Component` re-worked to call `InitializeElement()` when new elements were added, instead of calling `UpdateElement()`
+- Moved `Component` subscribe/unsubscribe code from `Start()`/`OnDestroy()` into `OnDisable()`/`OnDisable()`, respectively. This will enable `Component`s to be re-used (pooled).
+- `StateViewer` and `ComponentViewer` modified to handle `async Store.Instance` handle.
+
 ## [0.4.5] - 2024-10-21
 
 ### Fixed
 
-- Added a check to `Component.UpdateElementWithProps()` to also consider `Props.DidUpdate()`. If the element's props are comprised of both `PropsContainer` and `StateContainer`, missing this additional check can result in an `Element` (`Component`) updating, but receiving its old `StateContainer` props
+- Added a check to `Component.UpdateElementWithProps()` to also consider `Props.DidUpdate()` and then `Props.BuildProps()` if warranted. If the element's props are comprised of both `PropsContainer` and `StateContainer`, missing this additional check can result in an `Element` (`Component`) updating with its `PropsContainer`, but receiving its old `StateContainer` props
+
 
 ## [0.4.4] - 2024-10-03
 

--- a/Assets/UnityReact/Editor/CodeGeneration/PropsGenerator.cs
+++ b/Assets/UnityReact/Editor/CodeGeneration/PropsGenerator.cs
@@ -136,7 +136,7 @@ namespace Yohash.React.Editor
         } else if (stateContainerFields.Count == 0) {
           sb.AppendLine($"{b}    return true;");
         }
-        sb.AppendLine("  }");
+        sb.AppendLine("    }");
 
         // **** Generate BuildElement method
         if (propsContainerFields.Count > 0) {
@@ -148,6 +148,8 @@ namespace Yohash.React.Editor
           var fieldType = propsContainerFields[0].FieldType.Name;
           sb.AppendLine($"{b}    {fieldName} = propsContainer as {fieldType};");
           sb.AppendLine($"{b}  }}");
+          sb.AppendLine("");
+          sb.AppendLine($"{b}  public override bool HasCustomProps => true; ");
         }
 
         sb.AppendLine($"{b}}}");

--- a/Assets/UnityReact/Editor/StateViewer/ComponentViewer.cs
+++ b/Assets/UnityReact/Editor/StateViewer/ComponentViewer.cs
@@ -52,18 +52,23 @@ namespace Yohash.React.Editor
 
     private void Update()
     {
-      if (Store.Instance != null
-        && Store.Instance.OnStoreUpdate != null
-        && !Array.Exists(Store.Instance.OnStoreUpdate.GetInvocationList(), x => x.Method.Name == "updateComponentView")
-      ) {
-        Store.Instance.OnStoreUpdate += updateComponentView;
-      }
       if (!Application.isPlaying) {
         embeddedToggles = new Dictionary<string, managedToggle>();
+        return;
+      }
+      updateAsync();
+    }
+
+    private async void updateAsync()
+    {
+      var store = await Store.Instance;
+      if (store.OnStoreUpdate != null
+        && !Array.Exists(store.OnStoreUpdate.GetInvocationList(), x => x.Method.Name == "updateStateView")
+      ) {
+        store.OnStoreUpdate += updateComponentView;
       }
       Repaint();
     }
-
 
     private async void updateComponentView(State oldState, State newState)
     {

--- a/Assets/UnityReact/Editor/StateViewer/StateViewer.cs
+++ b/Assets/UnityReact/Editor/StateViewer/StateViewer.cs
@@ -44,14 +44,20 @@ namespace Yohash.React.Editor
 
     private void Update()
     {
-      if (Store.Instance != null
-        && Store.Instance.OnStoreUpdate != null
-        && !Array.Exists(Store.Instance.OnStoreUpdate.GetInvocationList(), x => x.Method.Name == "updateStateView")
-      ) {
-        Store.Instance.OnStoreUpdate += updateStateView;
-      }
       if (!Application.isPlaying) {
         embeddedToggles = new Dictionary<string, managedToggle>();
+        return;
+      }
+      updateAsync();
+    }
+
+    private async void updateAsync()
+    {
+      var store = await Store.Instance;
+      if (store.OnStoreUpdate != null
+        && !Array.Exists(store.OnStoreUpdate.GetInvocationList(), x => x.Method.Name == "updateStateView")
+      ) {
+        store.OnStoreUpdate += updateStateView;
       }
       Repaint();
     }
@@ -64,9 +70,9 @@ namespace Yohash.React.Editor
       populateState();
     }
 
-    private void populateState()
+    private async void populateState()
     {
-      var store = Store.Instance;
+      var store = await Store.Instance;
       if (store == null) {
         Debug.LogError("No instance of Store.");
         return;

--- a/Assets/UnityReact/README.md
+++ b/Assets/UnityReact/README.md
@@ -1,3 +1,10 @@
 # UnityReact
 
 This library contains a backend state-management system loosely modeled after React.
+
+[License](LICENSE.md)
+[Changelog](CHANGELOG.md)
+
+## Directions
+
+Coming soon.

--- a/Assets/UnityReact/Runtime/UnityReact/Component.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/Component.cs
@@ -140,7 +140,7 @@ namespace Yohash.React
         if (child.Component == null) { continue; }
         // update the child component, so it can receive the props update
         var newProps = propsContainer(child);
-        child.Component.UpdateElementWithProps(newProps, state);
+        child.Component.UpdateElement(newProps, state);
       }
 
       // this container can be null, if an element is mounted without a custom
@@ -162,7 +162,7 @@ namespace Yohash.React
       InitializeComponent();
     }
 
-    public void UpdateElementWithProps(PropsContainer propsContainer, State state)
+    public void UpdateElement(PropsContainer propsContainer, State state)
     {
       // TODO - is an "Element did change" style of method here worth while?
       //        Can we only update elements when needed?

--- a/Assets/UnityReact/Runtime/UnityReact/Component.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/Component.cs
@@ -19,19 +19,21 @@ namespace Yohash.React
     public void Unmount() => unmount();
 
     private bool isUpdating = false;
+    private Store _store;
 
     private void OnEnable()
     {
-      subscribe();
+      _ = subscribe();
     }
 
-    private void subscribe()
+    private async Task subscribe()
     {
+      _store = await Store.Instance;
       if (Store.Instance == null) {
-        throw new ComponentCreatedWithNoStore($"Component {name} was created with no Store instance.");
+        throw new ComponentCreatedWithNoStore($"Component {name} await store, was created with no Store instance.");
       }
 
-      Store.Instance.Subscribe(onStoreUpdate, onStoreInitialize);
+      _store.Subscribe(onStoreUpdate, onStoreInitialize);
     }
 
     private void OnDisable()
@@ -45,7 +47,7 @@ namespace Yohash.React
     /// </summary>
     internal void unmount()
     {
-      Store.Instance?.Unsubscribe(onStoreUpdate);
+      _store.Unsubscribe(onStoreUpdate);
       // iterate backwards over the children, destroying each one
       for (int i = children.Count - 1; i >= 0; i--) {
         var child = children.ElementAt(i);
@@ -56,7 +58,7 @@ namespace Yohash.React
 
     protected void dispatch(IAction action)
     {
-      Store.Instance.Dispatch(action);
+      _store.Dispatch(action);
     }
 
     internal void onStoreInitialize(State state)

--- a/Assets/UnityReact/Runtime/UnityReact/IComponent.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/IComponent.cs
@@ -6,8 +6,8 @@ namespace Yohash.React
   {
     Transform Transform { get; }
     UnityEngine.Object Object { get; }
+    void InitializeElement(PropsContainer props, State state);
     void UpdateElementWithProps(PropsContainer props, State state);
     void Unmount();
   }
 }
-

--- a/Assets/UnityReact/Runtime/UnityReact/IComponent.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/IComponent.cs
@@ -7,7 +7,7 @@ namespace Yohash.React
     Transform Transform { get; }
     UnityEngine.Object Object { get; }
     void InitializeElement(PropsContainer props, State state);
-    void UpdateElementWithProps(PropsContainer props, State state);
+    void UpdateElement(PropsContainer props, State state);
     void Unmount();
   }
 }

--- a/Assets/UnityReact/Runtime/UnityReact/Props.cs
+++ b/Assets/UnityReact/Runtime/UnityReact/Props.cs
@@ -9,5 +9,6 @@ namespace Yohash.React
     public virtual void BuildProps(State state) { }
     public virtual bool DidUpdate(State state) { return false; }
     public virtual void BuildElement(PropsContainer propsContainer) { }
+    public virtual bool HasCustomProps => false;
   };
 }

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs
@@ -17,6 +17,8 @@ namespace Yohash.React.Samples.BasicUi
     {
       ListObject = propsContainer as ListObjectProps;
     }
+
+    public override bool HasCustomProps => true; 
   }
 
   public partial class MenuProps : Props
@@ -55,6 +57,8 @@ namespace Yohash.React.Samples.BasicUi
     {
       Psychedlic = propsContainer as PsychedlicState;
     }
+
+    public override bool HasCustomProps => true; 
   }
 
   public partial class SubMenuProps : Props

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs.meta
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 875eab9aa0760ab45af866642b2a4fce
+guid: d00705cfa02e12d4597f10cfad39e213
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs.meta
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiPropsMethods.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c907fe4b30452043a2ae30f58aa2c17
+guid: 875eab9aa0760ab45af866642b2a4fce
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiState.cs.meta
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiState.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bd4fecc9153994d49941872a9b172a2e
+guid: 4283b8bd076cd834dbc0a248c73a7ba9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiState.cs.meta
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Generated/BasicUiState.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4283b8bd076cd834dbc0a248c73a7ba9
+guid: 2e2ddb5860a8ded4482e755c792d0d0c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/UnityReact/Samples~/SetupBasicUI/Scripts/MenuState.cs
+++ b/Assets/UnityReact/Samples~/SetupBasicUI/Scripts/MenuState.cs
@@ -29,6 +29,7 @@ namespace Yohash.React.Samples.BasicUi
             return true;
           }
         case ListRemoveObject _: {
+            if (ListValues.Length == 0) { return false; }
             Array.Resize(ref ListValues, ListValues.Length - 1);
             return true;
           }

--- a/Assets/UnityReact/package.json
+++ b/Assets/UnityReact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yohash.react",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "displayName": "UnityReact",
   "description": "A backend state management system loosely modeled after React",
   "unity": "2019.1",


### PR DESCRIPTION
Modify `Icomponent` with an `InitializeElement(PropsContainer, State)` to properly assemble element props and initialize.

The associated method was created in `Component` as well, and will (1) build props, (2) build element (`PropsContainer`) and (3) call `InitializeComponent()`

closes https://github.com/yohash/UnityReact/issues/18